### PR TITLE
Hiding the forgot option when not needed

### DIFF
--- a/lib/src/main/java/com/github/orangegangsters/lollipin/lib/managers/AppLock.java
+++ b/lib/src/main/java/com/github/orangegangsters/lollipin/lib/managers/AppLock.java
@@ -95,7 +95,7 @@ public abstract class AppLock {
     /**
      * Get the forgot option used by {@link com.github.orangegangsters.lollipin.lib.managers.AppLockActivity}
      */
-    public abstract boolean shouldShowForgot();
+    public abstract boolean shouldShowForgot(int appLockType);
 
     /**
      * Set the forgot option used by {@link com.github.orangegangsters.lollipin.lib.managers.AppLockActivity}

--- a/lib/src/main/java/com/github/orangegangsters/lollipin/lib/managers/AppLockActivity.java
+++ b/lib/src/main/java/com/github/orangegangsters/lollipin/lib/managers/AppLockActivity.java
@@ -128,7 +128,7 @@ public abstract class AppLockActivity extends PinActivity implements KeyboardBut
             logoImage.setImageResource(logoId);
         }
         mForgotTextView.setText(getForgotText());
-        mForgotTextView.setVisibility(mLockManager.getAppLock().shouldShowForgot() ? View.VISIBLE : View.GONE);
+        setForgotTextVisibility();
 
         setStepText();
     }
@@ -218,6 +218,10 @@ public abstract class AppLockActivity extends PinActivity implements KeyboardBut
         return getString(R.string.pin_code_forgot_text);
     }
 
+    private void setForgotTextVisibility(){
+        mForgotTextView.setVisibility(mLockManager.getAppLock().shouldShowForgot(mType) ? View.VISIBLE : View.GONE);
+    }
+
     /**
      * Overrides to allow a slide_down animation when finishing
      */
@@ -293,6 +297,7 @@ public abstract class AppLockActivity extends PinActivity implements KeyboardBut
                 setPinCode("");
                 mType = AppLock.CONFIRM_PIN;
                 setStepText();
+                setForgotTextVisibility();
                 break;
             case AppLock.CONFIRM_PIN:
                 if (mPinCode.equals(mOldPinCode)) {
@@ -305,6 +310,7 @@ public abstract class AppLockActivity extends PinActivity implements KeyboardBut
                     setPinCode("");
                     mType = AppLock.ENABLE_PINLOCK;
                     setStepText();
+                    setForgotTextVisibility();
                     onPinCodeError();
                 }
                 break;
@@ -312,6 +318,7 @@ public abstract class AppLockActivity extends PinActivity implements KeyboardBut
                 if (mLockManager.getAppLock().checkPasscode(mPinCode)) {
                     mType = AppLock.ENABLE_PINLOCK;
                     setStepText();
+                    setForgotTextVisibility();
                     setPinCode("");
                     onPinCodeSuccess();
                 } else {

--- a/lib/src/main/java/com/github/orangegangsters/lollipin/lib/managers/AppLockImpl.java
+++ b/lib/src/main/java/com/github/orangegangsters/lollipin/lib/managers/AppLockImpl.java
@@ -191,8 +191,9 @@ public class AppLockImpl<T extends AppLockActivity> extends AppLock implements L
     }
 
     @Override
-    public boolean shouldShowForgot() {
-        return mSharedPreferences.getBoolean(SHOW_FORGOT_PREFERENCE_KEY, true);
+    public boolean shouldShowForgot(int appLockType) {
+        return mSharedPreferences.getBoolean(SHOW_FORGOT_PREFERENCE_KEY, true)
+                && appLockType != AppLock.ENABLE_PINLOCK && appLockType != AppLock.CONFIRM_PIN;
     }
 
     @Override


### PR DESCRIPTION
This change will hide the forgot option from the `AppLockActivity` when in a state that it is not required such as first enabling, or confirming a new pin.
