### PR TITLE
Add override callback for checkPasscode & setPasscode

### DIFF
--- a/lib/src/main/java/com/github/orangegangsters/lollipin/lib/interfaces/ILockCallback.java
+++ b/lib/src/main/java/com/github/orangegangsters/lollipin/lib/interfaces/ILockCallback.java
@@ -1,0 +1,8 @@
+package com.github.orangegangsters.lollipin.lib.interfaces;
+
+public interface ILockCallback {
+
+    boolean onCheckPasscode(String inputPasscode);
+
+    boolean onSetPasscode(String passcode);
+}

--- a/lib/src/main/java/com/github/orangegangsters/lollipin/lib/managers/AppLock.java
+++ b/lib/src/main/java/com/github/orangegangsters/lollipin/lib/managers/AppLock.java
@@ -2,6 +2,8 @@ package com.github.orangegangsters.lollipin.lib.managers;
 
 import android.app.Activity;
 
+import com.github.orangegangsters.lollipin.lib.interfaces.ILockCallback;
+
 import java.util.HashSet;
 
 public abstract class AppLock {
@@ -103,6 +105,11 @@ public abstract class AppLock {
     public abstract void setShouldShowForgot(boolean showForgot);
 
     /**
+     * set callback to be called when passcode is checked or set.
+     */
+    public abstract void setCallback(ILockCallback lockCallback);
+
+    /**
      * Get whether the user backed out of the {@link AppLockActivity} previously
      */
     public abstract boolean pinChallengeCancelled();
@@ -170,6 +177,7 @@ public abstract class AppLock {
 
     /**
      * Enable or disable fingerprint authentication on the PIN screen.
+     *
      * @param enabled If true, enables the fingerprint reader if it is supported.  If false, will
      *                hide the fingerprint reader icon on the PIN screen.
      */

--- a/lib/src/main/java/com/github/orangegangsters/lollipin/lib/managers/AppLockImpl.java
+++ b/lib/src/main/java/com/github/orangegangsters/lollipin/lib/managers/AppLockImpl.java
@@ -14,6 +14,7 @@ import com.github.orangegangsters.lollipin.lib.PinCompatActivity;
 import com.github.orangegangsters.lollipin.lib.PinFragmentActivity;
 import com.github.orangegangsters.lollipin.lib.encryption.Encryptor;
 import com.github.orangegangsters.lollipin.lib.enums.Algorithm;
+import com.github.orangegangsters.lollipin.lib.interfaces.ILockCallback;
 import com.github.orangegangsters.lollipin.lib.interfaces.LifeCycleInterface;
 
 import java.security.SecureRandom;
@@ -96,6 +97,11 @@ public class AppLockImpl<T extends AppLockActivity> extends AppLock implements L
      * Static instance of {@link AppLockImpl}
      */
     private static AppLockImpl mInstance;
+
+    /**
+     * custom callback for checking and setting passcode.
+     */
+    private ILockCallback mLockCallback;
 
     /**
      * Static method that allows to get back the current static Instance of {@link AppLockImpl}
@@ -263,7 +269,15 @@ public class AppLockImpl<T extends AppLockActivity> extends AppLock implements L
     }
 
     @Override
+    public void setCallback(ILockCallback lockCallback) {
+        mLockCallback = lockCallback;
+    }
+
+    @Override
     public boolean checkPasscode(String passcode) {
+        if (mLockCallback != null) {
+            return mLockCallback.onCheckPasscode(passcode);
+        }
         Algorithm algorithm = Algorithm.getFromText(mSharedPreferences.getString(PASSWORD_ALGORITHM_PREFERENCE_KEY, ""));
 
         String salt = getSalt();
@@ -284,6 +298,9 @@ public class AppLockImpl<T extends AppLockActivity> extends AppLock implements L
 
     @Override
     public boolean setPasscode(String passcode) {
+        if (mLockCallback != null) {
+            return mLockCallback.onSetPasscode(passcode);
+        }
         String salt = getSalt();
         SharedPreferences.Editor editor = mSharedPreferences.edit();
 


### PR DESCRIPTION
I needed to have a different process to manage `checkPasscode` & `setPasscode` so I added callback for each of those 2 methods. A sample usecase of this would be a SIM application that holds the pincode, in that case, the pin code shouldn't be stored in `SharedPreferences` since the pin code is checked and set on the SIM card.

Exemple in `onCreate` of `CustomPinActivity` : 

```java
LockManager<CustomPinActivity> lockManager = LockManager.getInstance();
lockManager.getAppLock().setCallback(new ILockCallback() {
    @Override
    public boolean onCheckPasscode(String inputPasscode) {
        //check pin code on SIM card
        return false;
    }

    @Override
    public boolean onSetPasscode(String passcode) {
        //set pin code on SIM card
        return false;
    }
});
```