### PR TITLE
Fix for PIN lock bypass when app is killed or repeatedly paused

### DIFF
--- a/lib/src/main/java/com/github/omadahealth/lollipin/lib/PinActivity.java
+++ b/lib/src/main/java/com/github/omadahealth/lollipin/lib/PinActivity.java
@@ -40,6 +40,14 @@ public class PinActivity extends Activity {
     }
 
     @Override
+    public void onUserInteraction() {
+        if (mLifeCycleListener != null){
+            mLifeCycleListener.onActivityUserInteraction(PinActivity.this);
+        }
+        super.onUserInteraction();
+    }
+
+    @Override
     protected void onResume() {
         if (mLifeCycleListener != null) {
             mLifeCycleListener.onActivityResumed(PinActivity.this);

--- a/lib/src/main/java/com/github/omadahealth/lollipin/lib/PinCompatActivity.java
+++ b/lib/src/main/java/com/github/omadahealth/lollipin/lib/PinCompatActivity.java
@@ -47,6 +47,14 @@ public class PinCompatActivity extends AppCompatActivity {
     }
 
     @Override
+    public void onUserInteraction() {
+        if (mLifeCycleListener != null){
+            mLifeCycleListener.onActivityUserInteraction(PinCompatActivity.this);
+        }
+        super.onUserInteraction();
+    }
+
+    @Override
     protected void onPause() {
         if (mLifeCycleListener != null) {
             mLifeCycleListener.onActivityPaused(PinCompatActivity.this);

--- a/lib/src/main/java/com/github/omadahealth/lollipin/lib/PinFragmentActivity.java
+++ b/lib/src/main/java/com/github/omadahealth/lollipin/lib/PinFragmentActivity.java
@@ -47,6 +47,14 @@ public class PinFragmentActivity extends FragmentActivity {
     }
 
     @Override
+    public void onUserInteraction() {
+        if (mLifeCycleListener != null){
+            mLifeCycleListener.onActivityUserInteraction(PinFragmentActivity.this);
+        }
+        super.onUserInteraction();
+    }
+
+    @Override
     protected void onPause() {
         if (mLifeCycleListener != null) {
             mLifeCycleListener.onActivityPaused(PinFragmentActivity.this);

--- a/lib/src/main/java/com/github/omadahealth/lollipin/lib/interfaces/LifeCycleInterface.java
+++ b/lib/src/main/java/com/github/omadahealth/lollipin/lib/interfaces/LifeCycleInterface.java
@@ -17,6 +17,11 @@ public interface LifeCycleInterface {
     public void onActivityResumed(Activity activity);
 
     /**
+     * Called in {@link Activity#onUserInteraction()}
+     */
+    public void onActivityUserInteraction(Activity activity);
+
+    /**
      * Called in {@link android.app.Activity#onPause()}
      */
     public void onActivityPaused(Activity activity);

--- a/lib/src/main/java/com/github/omadahealth/lollipin/lib/managers/AppLockImpl.java
+++ b/lib/src/main/java/com/github/omadahealth/lollipin/lib/managers/AppLockImpl.java
@@ -380,7 +380,14 @@ public class AppLockImpl<T extends AppLockActivity> extends AppLock implements L
         String clazzName = activity.getClass().getName();
         Log.d(TAG, "onActivityPaused " + clazzName);
 
-        if ((onlyBackgroundTimeout() || !shouldLockSceen(activity)) && !(activity instanceof AppLockActivity)) {
+        if (!shouldLockSceen(activity) && !(activity instanceof AppLockActivity)) {
+            setLastActiveMillis();
+        }
+    }
+
+    @Override
+    public void onActivityUserInteraction(Activity activity) {
+        if (onlyBackgroundTimeout() && !shouldLockSceen(activity) && !(activity instanceof AppLockActivity)) {
             setLastActiveMillis();
         }
     }


### PR DESCRIPTION
Several issues reported that the PIN lock can be bypassed, which was related to the `onlyBackgroundTimeout` setting. The root cause was the logic deciding when the user was last active. This PR fixes these issues. 

The issues could be reproduced in the demo app when setting `onlyBackgroundTimeOut` to true:

- Launch the app
- Set the expiry to N seconds (or use the default 10 seconds)
- Kill the app
- Wait N + 1 seconds
- Launch the app

Or (not 100% reproducible on all devices)

- Launch the app
- Set the expiry to N seconds (or use the default 10 seconds)
- Send to background via home button 
- Wait N + 1 seconds
- Launch the app
- Send to background via home button 
- Launch the app

This PR keeps the previous functionality and additionally enhances the behavior when onlyBackground is set to true.

Issues addressed:

[#130](https://github.com/omadahealth/LolliPin/issues/130)
[#153](https://github.com/omadahealth/LolliPin/issues/153)
[#131](https://github.com/omadahealth/LolliPin/issues/131)
[#99](https://github.com/omadahealth/LolliPin/issues/99)